### PR TITLE
Avoid allocation failure of sigstack

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_posix_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_posix_libcdep.cpp
@@ -165,7 +165,12 @@ bool SupportsColoredOutput(fd_t fd) {
 
 #if !SANITIZER_GO
 // TODO(glider): different tools may require different altstack size.
-static const uptr kAltStackSize = SIGSTKSZ * 4;  // SIGSTKSZ is not enough.
+static uptr GetAltStackSize() {
+  // Note: since GLIBC_2.31, SIGSTKSZ may be a function call, so this may be
+  // more costly that you think. However GetAltStackSize is only call 2-3 times
+  // per thread so don't cache the evaluation.
+  return SIGSTKSZ * 4;
+}
 
 void SetAlternateSignalStack() {
   stack_t altstack, oldstack;
@@ -176,10 +181,10 @@ void SetAlternateSignalStack() {
   // TODO(glider): the mapped stack should have the MAP_STACK flag in the
   // future. It is not required by man 2 sigaltstack now (they're using
   // malloc()).
-  void* base = MmapOrDie(kAltStackSize, __func__);
+  void* base = MmapOrDie(GetAltStackSize(), __func__);
   altstack.ss_sp = (char*) base;
   altstack.ss_flags = 0;
-  altstack.ss_size = kAltStackSize;
+  altstack.ss_size = GetAltStackSize();
   CHECK_EQ(0, sigaltstack(&altstack, nullptr));
 }
 
@@ -187,7 +192,7 @@ void UnsetAlternateSignalStack() {
   stack_t altstack, oldstack;
   altstack.ss_sp = nullptr;
   altstack.ss_flags = SS_DISABLE;
-  altstack.ss_size = kAltStackSize;  // Some sane value required on Darwin.
+  altstack.ss_size = GetAltStackSize();  // Some sane value required on Darwin.
   CHECK_EQ(0, sigaltstack(&altstack, &oldstack));
   UnmapOrDie(oldstack.ss_sp, oldstack.ss_size);
 }


### PR DESCRIPTION
## The problem
If we compile videzzo-llvm-project toolchain within ViDeZZo container and use the toolchain to compile binaries with `-fsanitizer=address`, asan will fail to allocate the signal stack.
```
==8915==ERROR: AddressSanitizer failed to allocate 0x0 (0) bytes of SetAlternateSignalStack (error code: 22)
```
This problem has been reported by https://github.com/HexHive/ViDeZZo/issues/16. 

## Step to reproduce
1.Compile videzzo-llvm-project within the ViDeZZo container. 
```bash
git clone https://github.com/cyruscyliu/videzzo-llvm-project.git llvm-project --depth=1
pushd llvm-project && mkdir build-custom && pushd build-custom
cmake -G Ninja -DLLVM_ENABLE_PROJECTS="clang;compiler-rt;lld" \
    -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_OPTIMIZED_TABLEGEN=ON ../llvm/
ninja clang compiler-rt llvm-symbolizer llvm-profdata llvm-cov \
    llvm-config lld llvm-dis opt
popd && popd
```
2.A minimal test case. Save this code to /tmp/test.c, compile and run.
```c
#include <stdlib.h>
int main(int argc, char *argv[]) {
  char *p = (char*)malloc(0x10);
  p[0x9] = 0x18;
  free(p); 
  p = nullptr;
  return 0;
}
```
```bash
./bin/clang -o /tmp/test /tmp/test.c -fsanitize=address
/tmp/test
```

## Root cause
As the code below shows, the size of signal handler stack is determined by kAltStackSize which is initialized with SIGSTKSZ*4. 
However, within the videzzo container, SIGSTKSZ is not a compile-time constant but a call to sysconf. 

Thus, kAltStackSize will be initilized in .init_array. However, SetAlternateSignalStack is called in .preinit_array, which is before .init_array. So, while calling MmapOrDie from SetAlternateSignalStack, the kAltStackSize is still uninitilized (with value 0). 

```cpp
static const uptr kAltStackSize = SIGSTKSZ * 4;  // SIGSTKSZ is not enough.

void SetAlternateSignalStack() {
  stack_t altstack, oldstack;
  CHECK_EQ(0, sigaltstack(nullptr, &oldstack));
  // If the alternate stack is already in place, do nothing.
  // Android always sets an alternate stack, but it's too small for us.
  if (!SANITIZER_ANDROID && !(oldstack.ss_flags & SS_DISABLE)) return;
  // TODO(glider): the mapped stack should have the MAP_STACK flag in the
  // future. It is not required by man 2 sigaltstack now (they're using
  // malloc()).
  void* base = MmapOrDie(kAltStackSize, __func__);
  altstack.ss_sp = (char*) base;
  altstack.ss_flags = 0;
  altstack.ss_size = kAltStackSize;
  CHECK_EQ(0, sigaltstack(&altstack, nullptr));
}
```
This has been discussed in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100114 and a patch is at https://github.com/llvm/llvm-project/commit/82150606fb11d28813ae6da1101f5bda638165fe

## Solution
Just pick the changes from llvm-project main stream. 